### PR TITLE
Fix custom model load

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,5 +1,5 @@
 SEED: 12345 # Random seed for reproducibility of sampled datasets and model initialisation
-MODEL: 'EN0' # EN:[0,2,S,M,L,X] (e.g. ENS): CN:[P,N,T,S,B,L] (e.g. CNB); VT:[T,S,B,L] (e.g. VTS) or pretrained filename with model as first 3 char e.g. 'ens_pt.keras'
+MODEL: 'EN0' # EN:[0,2,S,M,L,X] (e.g. ENS): CN:[P,N,T,S,B,L] (e.g. CNB); VT:[T,S,B,L] (e.g. VTS) or pretrained filename with model as first 3 char e.g. '/model/ens_pt.keras'
 SAVEFILE: 'case_study' # Filename to save .keras model : MODEL name appended automatically
 OUTPUT_PATH: '/data/output' # Save Path for output files (model, class map, confusion matrix): SAVEFILE/MODEL added automatically to path
 

--- a/src/mewc_train.py
+++ b/src/mewc_train.py
@@ -8,7 +8,7 @@ import tensorflow as tf
 print("\nTensorFlow version:", tf.__version__)
 
 from tqdm import tqdm # for progress bar
-from lib_common import update_config_from_env, model_img_size_mapping, read_yaml, setup_strategy
+from lib_common import update_config_from_env, model_img_size_mapping, read_yaml, setup_strategy, get_mod
 from lib_model import build_classifier, fit_frozen, fit_progressive, calc_class_metrics
 from lib_data import print_dsinfo, create_train, create_fixed, process_samples_from_config, ensure_output_directory, validate_directory_structure
 
@@ -16,11 +16,11 @@ config = update_config_from_env(read_yaml("config.yaml"))
 custom_sample_file, is_custom_sample = process_samples_from_config(config)
 
 strategy = setup_strategy() # Set up the strategy for distributed training
-output_fpath = os.path.join(config['OUTPUT_PATH'], config['SAVEFILE'], config['MODEL'])
+output_fpath = os.path.join(config['OUTPUT_PATH'], config['SAVEFILE'], get_mod(config['MODEL']))
 ensure_output_directory(output_fpath)
 validate_directory_structure(config['TRAIN_PATH'], config['VAL_PATH'], config['TEST_PATH'])
 
-img_size = model_img_size_mapping(config['MODEL'])
+img_size = model_img_size_mapping(get_mod(config['MODEL']))
 
 train_df, num_classes = create_train(
     config['TRAIN_PATH'],


### PR DESCRIPTION
Used function call from mewc-flow to fix custom model loads for fine-tuning.
- Tested with local build.
- Works whether uses specify model name (e.g., 'ENS' or 'ens') or filename (e.g., 'ens_pt.keras') or path (e.g., '/model/ens_pt.keras').
Assumptions are that the first 3 letters of the model name equates to an existing model (as before), and that the file type is .keras (as before).
- Updated default config with `/model/ens_pt.keras' example in the config.yaml

